### PR TITLE
deps(pip): pin docker to 7.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docker==5.0.3
+docker==7.1.0
 requests~=2.27
 gunicorn~=20.1
 flask~=2.0
@@ -6,4 +6,3 @@ yapf~=0.32
 pydantic~=1.9
 redis~=4.1.4
 
-urllib3<2


### PR DESCRIPTION
see: https://github.com/docker/docker-py/issues/3256