### PR TITLE
build(dockerfile): update maintainer label to OCI image authors state…

### DIFF
--- a/c_cpp_dockerfile
+++ b/c_cpp_dockerfile
@@ -2,7 +2,7 @@
 
 FROM ubuntu:18.04
 
-LABEL maintainer="Normal-OJ"
+LABEL org.opencontainers.image.authors="Normal-OJ Maintainers <admin@noj.tw>"
 
 # update
 RUN apt-get update -y

--- a/python3_dockerfile
+++ b/python3_dockerfile
@@ -2,7 +2,7 @@
 
 FROM ubuntu:18.04
 
-LABEL maintainer="Normal-OJ"
+LABEL org.opencontainers.image.authors="Normal-OJ Maintainers <admin@noj.tw>"
 
 # update
 RUN apt-get update -y


### PR DESCRIPTION
…d in doc

Fix #41

I've thought to use admin@noj.tw instead of Normal-OJ. But I think using Normal-OJ would be better as people can find more information by searching this name, compared to an email.