### PR TITLE
fix: Make Continuous Integration Work

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -3,28 +3,56 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
-
+  lint:
+    name: Code Style Check
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Upgrade pip
-      run: |
-        python -m pip install --upgrade pip
-    - name: Install sandbox requirements
-      run: |
-        ./build.sh
-        pip install -r requirements.txt
-    - name: YAPF
-      run: |
-        pip install yapf
-        yapf . -rd
-    - name: Unit test
-      run: |
-        pip install -r tests/requirements.txt
-        pytest
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      
+      - name: Install YAPF
+        run: |
+          python -m pip install --upgrade pip
+          pip install yapf
+      
+      - name: Check code formatting
+        run: yapf . -rd
+  
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      
+      - name: Cache build dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/tests/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      
+      - name: Build sandbox
+        run: ./build.sh
+      
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r tests/requirements.txt
+      
+      - name: Run tests
+        run: pytest -v

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   lint:
     name: Code Style Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       
@@ -25,7 +25,7 @@ jobs:
   
   test:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       

--- a/c_cpp_dockerfile
+++ b/c_cpp_dockerfile
@@ -1,6 +1,6 @@
 # for c_cpp
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.authors="Normal-OJ Maintainers <admin@noj.tw>"
 

--- a/dispatcher/config.py
+++ b/dispatcher/config.py
@@ -13,7 +13,7 @@ SANDBOX_TOKEN = os.getenv(
 )
 TESTDATA_ROOT = Path(os.getenv(
     'TESTDATA_ROOT',
-    '/sandbox-testdata',
+    'sandbox-testdata',
 ))
 TESTDATA_ROOT.mkdir(exist_ok=True)
 SUBMISSION_DIR = Path(os.getenv(

--- a/python3_dockerfile
+++ b/python3_dockerfile
@@ -1,6 +1,6 @@
 # for python3
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.authors="Normal-OJ Maintainers <admin@noj.tw>"
 

--- a/tests/test_submission_runner.py
+++ b/tests/test_submission_runner.py
@@ -26,8 +26,8 @@ import pytest
     ],
 )
 def test_strip_func(TestSubmissionRunner, stdout, answer, excepted):
-    assert (TestSubmissionRunner.strip(stdout)
-            == TestSubmissionRunner.strip(answer)) is excepted
+    assert (TestSubmissionRunner.strip(stdout) == TestSubmissionRunner.strip(
+        answer)) is excepted
 
 
 def test_c_tle(submission_generator, TestSubmissionRunner):


### PR DESCRIPTION
- Bump Python from 3.7 to 3.10
- Bump actions/checkout from v1 to v4
- Bump actions/setup-python from v1 to v5
- Make the default testdata_root path from `/sandbox-testdata` to `sandbox-testdata`