### PR TITLE
Revert "ci: use arm runner"

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   lint:
     name: Code Style Check
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       
@@ -25,7 +25,7 @@ jobs:
   
   test:
     name: Unit Tests
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
FYI, we should use x86-64 runner in light of production environment.

This reverts commit dd2c392c9659b0193ff16c8c10bd2cbb93c2ab30.