### PR TITLE
feat: add pull-based runner client (GitHub Actions runner style)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,11 @@ WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-CMD ["gunicorn", "-c", "gunicorn.conf.py", "app:app"]
+# SANDBOX_MODE: "push" (default, legacy Flask server) or "pull" (runner client)
+ENV SANDBOX_MODE=push
+
+CMD if [ "$SANDBOX_MODE" = "pull" ]; then \
+      python runner_client.py; \
+    else \
+      gunicorn -c gunicorn.conf.py app:app; \
+    fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN pip install -r requirements.txt
 ENV SANDBOX_MODE=push
 
 CMD if [ "$SANDBOX_MODE" = "pull" ]; then \
-      python runner_client.py; \
+      exec python runner_client.py; \
     else \
-      gunicorn -c gunicorn.conf.py app:app; \
+      exec gunicorn -c gunicorn.conf.py app:app; \
     fi

--- a/runner_client.py
+++ b/runner_client.py
@@ -47,7 +47,8 @@ logger = logging.getLogger('runner')
 
 # Configuration from environment
 BACKEND_API = os.getenv('BACKEND_API', 'http://web:8080')
-RUNNER_TOKEN = os.getenv('RUNNER_TOKEN', os.getenv('SANDBOX_TOKEN', 'KoNoSandboxDa'))
+RUNNER_TOKEN = os.getenv('RUNNER_TOKEN',
+                         os.getenv('SANDBOX_TOKEN', 'KoNoSandboxDa'))
 RUNNER_NAME = os.getenv('RUNNER_NAME', os.uname().nodename)
 POLL_INTERVAL = int(os.getenv('POLL_INTERVAL', '5'))
 MAX_CONCURRENT = int(os.getenv('MAX_CONCURRENT', '4'))
@@ -90,7 +91,8 @@ class Runner:
                 timeout=30,
             )
             if not resp.ok:
-                logger.warning(f'Failed to poll for jobs: {resp.status_code} {resp.text}')
+                logger.warning(
+                    f'Failed to poll for jobs: {resp.status_code} {resp.text}')
                 return []
             data = resp.json().get('data', {})
             return data.get('jobs', [])
@@ -109,7 +111,8 @@ class Runner:
                 logger.info(f'Job {submission_id} already claimed')
                 return None
             if not resp.ok:
-                logger.warning(f'Failed to claim job {submission_id}: {resp.status_code}')
+                logger.warning(
+                    f'Failed to claim job {submission_id}: {resp.status_code}')
                 return None
             data = resp.json()['data']
             return JobInfo(
@@ -169,10 +172,8 @@ class Runner:
             timeout=60,
         )
         if not resp.ok:
-            logger.error(
-                f'Failed to report result for {submission_id}: '
-                f'{resp.status_code} {resp.text}'
-            )
+            logger.error(f'Failed to report result for {submission_id}: '
+                         f'{resp.status_code} {resp.text}')
             return False
         return True
 
@@ -260,11 +261,13 @@ class Runner:
                     # Read config to get working_dir for host paths
                     with open('.config/submission.json') as f:
                         s_config = json.load(f)
-                    host_base = pathlib.Path(s_config['working_dir']) / submission_id / 'testcase'
+                    host_base = pathlib.Path(
+                        s_config['working_dir']) / submission_id / 'testcase'
                     container_base = submission_dir / 'testcase'
 
                     in_path = str((host_base / f'{case_no}.in').absolute())
-                    out_path = str((container_base / f'{case_no}.out').absolute())
+                    out_path = str(
+                        (container_base / f'{case_no}.out').absolute())
 
                     logger.info(f'Executing {submission_id}/{case_no}')
                     runner = SubmissionRunner(
@@ -357,7 +360,7 @@ class Runner:
 
                 thread = threading.Thread(
                     target=self.process_job,
-                    args=(job,),
+                    args=(job, ),
                     daemon=True,
                 )
                 thread.start()

--- a/runner_client.py
+++ b/runner_client.py
@@ -1,0 +1,378 @@
+"""
+Pull-based runner client for Normal OJ Sandbox.
+
+Works like a GitHub Actions self-hosted runner:
+1. Polls the backend for pending judge jobs
+2. Claims a job
+3. Downloads code and test data
+4. Compiles and executes in Docker containers
+5. Reports results back to the backend
+
+Usage:
+    python runner_client.py
+
+Environment variables:
+    BACKEND_API     - Backend server URL (default: http://web:8080)
+    RUNNER_TOKEN    - Authentication token (default: KoNoSandboxDa)
+    RUNNER_NAME     - Unique runner name (default: hostname)
+    POLL_INTERVAL   - Seconds between polls (default: 5)
+    MAX_CONCURRENT  - Max concurrent jobs (default: 4)
+"""
+
+import io
+import json
+import logging
+import os
+import pathlib
+import shutil
+import signal
+import sys
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from zipfile import ZipFile
+
+import requests
+
+from dispatcher.constant import Language
+from dispatcher.meta import Meta
+from runner.submission import SubmissionRunner
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] %(name)s: %(message)s',
+)
+logger = logging.getLogger('runner')
+
+# Configuration from environment
+BACKEND_API = os.getenv('BACKEND_API', 'http://web:8080')
+RUNNER_TOKEN = os.getenv('RUNNER_TOKEN', os.getenv('SANDBOX_TOKEN', 'KoNoSandboxDa'))
+RUNNER_NAME = os.getenv('RUNNER_NAME', os.uname().nodename)
+POLL_INTERVAL = int(os.getenv('POLL_INTERVAL', '5'))
+MAX_CONCURRENT = int(os.getenv('MAX_CONCURRENT', '4'))
+SUBMISSION_DIR = pathlib.Path(os.getenv('SUBMISSION_DIR', 'submissions'))
+HEARTBEAT_INTERVAL = 60  # seconds
+
+SUBMISSION_DIR.mkdir(exist_ok=True)
+
+
+@dataclass
+class JobInfo:
+    submission_id: str
+    problem_id: int
+    language: int
+    token: str
+    meta: dict
+
+
+class Runner:
+    """
+    A pull-based runner that polls the backend for jobs,
+    similar to a GitHub Actions self-hosted runner.
+    """
+
+    def __init__(self):
+        self.session = requests.Session()
+        self.session.headers.update({
+            'X-Runner-Token': RUNNER_TOKEN,
+            'X-Runner-Name': RUNNER_NAME,
+        })
+        self.running_jobs = 0
+        self.running_lock = threading.Lock()
+        self.shutdown = False
+
+    def poll_for_jobs(self):
+        """Poll the backend for available jobs."""
+        try:
+            resp = self.session.get(
+                f'{BACKEND_API}/runner/jobs',
+                timeout=30,
+            )
+            if not resp.ok:
+                logger.warning(f'Failed to poll for jobs: {resp.status_code} {resp.text}')
+                return []
+            data = resp.json().get('data', {})
+            return data.get('jobs', [])
+        except requests.RequestException as e:
+            logger.error(f'Error polling for jobs: {e}')
+            return []
+
+    def claim_job(self, submission_id: str) -> JobInfo | None:
+        """Claim a job from the backend."""
+        try:
+            resp = self.session.post(
+                f'{BACKEND_API}/runner/jobs/{submission_id}/claim',
+                timeout=30,
+            )
+            if resp.status_code == 409:
+                logger.info(f'Job {submission_id} already claimed')
+                return None
+            if not resp.ok:
+                logger.warning(f'Failed to claim job {submission_id}: {resp.status_code}')
+                return None
+            data = resp.json()['data']
+            return JobInfo(
+                submission_id=data['submissionId'],
+                problem_id=data['problemId'],
+                language=data['language'],
+                token=data['token'],
+                meta=data['meta'],
+            )
+        except requests.RequestException as e:
+            logger.error(f'Error claiming job {submission_id}: {e}')
+            return None
+
+    def download_code(self, submission_id: str, dest_dir: pathlib.Path):
+        """Download source code zip and extract to dest_dir/src/."""
+        resp = self.session.get(
+            f'{BACKEND_API}/runner/jobs/{submission_id}/code',
+            timeout=60,
+        )
+        resp.raise_for_status()
+        src_dir = dest_dir / 'src'
+        src_dir.mkdir(exist_ok=True)
+        with ZipFile(io.BytesIO(resp.content)) as zf:
+            zf.extractall(src_dir)
+
+    def download_testdata(self, submission_id: str, dest_dir: pathlib.Path):
+        """Download testdata zip and extract to dest_dir/testcase/."""
+        resp = self.session.get(
+            f'{BACKEND_API}/runner/jobs/{submission_id}/testdata',
+            timeout=120,
+        )
+        resp.raise_for_status()
+        testcase_dir = dest_dir / 'testcase'
+        testcase_dir.mkdir(exist_ok=True)
+        with ZipFile(io.BytesIO(resp.content)) as zf:
+            zf.extractall(testcase_dir)
+
+    def send_heartbeat(self, submission_id: str):
+        """Send heartbeat to extend claim timeout."""
+        try:
+            self.session.post(
+                f'{BACKEND_API}/runner/heartbeat',
+                json={'submissionId': submission_id},
+                timeout=10,
+            )
+        except requests.RequestException:
+            pass
+
+    def report_result(self, submission_id: str, token: str, tasks: list):
+        """Report job completion to the backend."""
+        resp = self.session.put(
+            f'{BACKEND_API}/runner/jobs/{submission_id}/complete',
+            json={
+                'tasks': tasks,
+                'token': token,
+            },
+            timeout=60,
+        )
+        if not resp.ok:
+            logger.error(
+                f'Failed to report result for {submission_id}: '
+                f'{resp.status_code} {resp.text}'
+            )
+            return False
+        return True
+
+    def process_job(self, job: JobInfo):
+        """
+        Process a single job: download data, compile, execute, report.
+        Runs in a separate thread.
+        """
+        submission_id = job.submission_id
+        submission_dir = SUBMISSION_DIR / submission_id
+        heartbeat_stop = threading.Event()
+
+        try:
+            logger.info(f'Processing job {submission_id} '
+                        f'[problem={job.problem_id}, lang={job.language}]')
+
+            # Prepare submission directory
+            if submission_dir.exists():
+                shutil.rmtree(submission_dir)
+            submission_dir.mkdir(parents=True)
+
+            # Write meta.json
+            meta = Meta.parse_obj(job.meta)
+            (submission_dir / 'meta.json').write_text(meta.json())
+
+            # Download code and testdata
+            self.download_code(submission_id, submission_dir)
+            self.download_testdata(submission_id, submission_dir)
+
+            # Move chaos files to src directory (same as file_manager.extract)
+            testcase_dir = submission_dir / 'testcase'
+            src_dir = submission_dir / 'src'
+            chaos_dir = testcase_dir / 'chaos'
+            if chaos_dir.exists() and chaos_dir.is_dir():
+                for chaos_file in chaos_dir.iterdir():
+                    shutil.move(str(chaos_file), str(src_dir))
+                os.rmdir(chaos_dir)
+
+            # Start heartbeat thread
+            def heartbeat_loop():
+                while not heartbeat_stop.is_set():
+                    heartbeat_stop.wait(HEARTBEAT_INTERVAL)
+                    if not heartbeat_stop.is_set():
+                        self.send_heartbeat(submission_id)
+
+            hb_thread = threading.Thread(target=heartbeat_loop, daemon=True)
+            hb_thread.start()
+
+            # Compile if needed
+            lang = Language(job.language)
+            lang_str = ['c11', 'cpp17', 'python3'][int(lang)]
+            compile_result = None
+
+            if lang in {Language.C, Language.CPP}:
+                logger.info(f'Compiling {submission_id}')
+                compile_result = SubmissionRunner(
+                    submission_id=submission_id,
+                    time_limit=-1,
+                    mem_limit=-1,
+                    testdata_input_path='',
+                    testdata_output_path='',
+                    lang=lang_str,
+                ).compile()
+                logger.info(f'Compile result: {compile_result["Status"]}')
+
+            # Execute each test case
+            results = {}
+            for i, task in enumerate(meta.tasks):
+                for j in range(task.caseCount):
+                    case_no = f'{i:02d}{j:02d}'
+
+                    # Check compile result
+                    if compile_result and compile_result['Status'] == 'CE':
+                        results[case_no] = {
+                            'stdout': compile_result.get('Stdout', ''),
+                            'stderr': compile_result.get('Stderr', ''),
+                            'exitCode': -1,
+                            'execTime': -1,
+                            'memoryUsage': -1,
+                            'status': 'CE',
+                        }
+                        continue
+
+                    # Build paths
+                    # Read config to get working_dir for host paths
+                    with open('.config/submission.json') as f:
+                        s_config = json.load(f)
+                    host_base = pathlib.Path(s_config['working_dir']) / submission_id / 'testcase'
+                    container_base = submission_dir / 'testcase'
+
+                    in_path = str((host_base / f'{case_no}.in').absolute())
+                    out_path = str((container_base / f'{case_no}.out').absolute())
+
+                    logger.info(f'Executing {submission_id}/{case_no}')
+                    runner = SubmissionRunner(
+                        submission_id=submission_id,
+                        time_limit=task.timeLimit,
+                        mem_limit=task.memoryLimit,
+                        testdata_input_path=in_path,
+                        testdata_output_path=out_path,
+                        lang=lang_str,
+                    )
+                    res = runner.run()
+                    results[case_no] = {
+                        'stdout': res.get('Stdout', ''),
+                        'stderr': res.get('Stderr', ''),
+                        'exitCode': res.get('DockerExitCode', -1),
+                        'execTime': res.get('Duration', -1),
+                        'memoryUsage': res.get('MemUsage', -1),
+                        'status': res['Status'],
+                    }
+
+            # Convert results to task-based format
+            submission_result = {}
+            for no, r in results.items():
+                task_no = int(no[:2])
+                case_no = int(no[2:])
+                if task_no not in submission_result:
+                    submission_result[task_no] = {}
+                submission_result[task_no][case_no] = r
+
+            task_list = []
+            for task_no in sorted(submission_result.keys()):
+                cases = submission_result[task_no]
+                task_list.append([cases[c] for c in sorted(cases.keys())])
+
+            # Report results
+            logger.info(f'Reporting results for {submission_id}')
+            success = self.report_result(submission_id, job.token, task_list)
+            if success:
+                logger.info(f'Job {submission_id} completed successfully')
+                # Clean up
+                shutil.rmtree(submission_dir, ignore_errors=True)
+            else:
+                logger.error(f'Failed to report results for {submission_id}')
+
+        except Exception as e:
+            logger.exception(f'Error processing job {submission_id}: {e}')
+        finally:
+            heartbeat_stop.set()
+            with self.running_lock:
+                self.running_jobs -= 1
+
+    def run(self):
+        """Main runner loop — poll, claim, process."""
+        logger.info(f'Runner "{RUNNER_NAME}" starting')
+        logger.info(f'Backend: {BACKEND_API}')
+        logger.info(f'Max concurrent jobs: {MAX_CONCURRENT}')
+        logger.info(f'Poll interval: {POLL_INTERVAL}s')
+
+        # Handle graceful shutdown
+        def on_signal(signum, frame):
+            logger.info('Shutting down...')
+            self.shutdown = True
+
+        signal.signal(signal.SIGINT, on_signal)
+        signal.signal(signal.SIGTERM, on_signal)
+
+        while not self.shutdown:
+            # Check if we can take more jobs
+            with self.running_lock:
+                available_slots = MAX_CONCURRENT - self.running_jobs
+
+            if available_slots <= 0:
+                time.sleep(POLL_INTERVAL)
+                continue
+
+            # Poll for jobs
+            jobs = self.poll_for_jobs()
+            if not jobs:
+                time.sleep(POLL_INTERVAL)
+                continue
+
+            # Try to claim and process jobs
+            for job_info in jobs[:available_slots]:
+                job = self.claim_job(job_info['submissionId'])
+                if job is None:
+                    continue
+
+                with self.running_lock:
+                    self.running_jobs += 1
+
+                thread = threading.Thread(
+                    target=self.process_job,
+                    args=(job,),
+                    daemon=True,
+                )
+                thread.start()
+
+            time.sleep(POLL_INTERVAL)
+
+        # Wait for running jobs to finish
+        logger.info('Waiting for running jobs to complete...')
+        while True:
+            with self.running_lock:
+                if self.running_jobs == 0:
+                    break
+            time.sleep(1)
+        logger.info('Runner stopped')
+
+
+if __name__ == '__main__':
+    Runner().run()

--- a/runner_client.py
+++ b/runner_client.py
@@ -26,8 +26,6 @@ import os
 import pathlib
 import shutil
 import signal
-import sys
-import tempfile
 import threading
 import time
 from dataclasses import dataclass
@@ -56,6 +54,16 @@ SUBMISSION_DIR = pathlib.Path(os.getenv('SUBMISSION_DIR', 'submissions'))
 HEARTBEAT_INTERVAL = 60  # seconds
 
 SUBMISSION_DIR.mkdir(exist_ok=True)
+
+
+def _safe_extractall(zf: ZipFile, dest: pathlib.Path):
+    """Extract zip while rejecting paths that escape dest (Zip Slip)."""
+    dest = dest.resolve()
+    for member in zf.infolist():
+        target = (dest / member.filename).resolve()
+        if not str(target).startswith(str(dest) + os.sep) and target != dest:
+            raise ValueError(f'Zip Slip detected: {member.filename}')
+    zf.extractall(dest)
 
 
 @dataclass
@@ -136,7 +144,7 @@ class Runner:
         src_dir = dest_dir / 'src'
         src_dir.mkdir(exist_ok=True)
         with ZipFile(io.BytesIO(resp.content)) as zf:
-            zf.extractall(src_dir)
+            _safe_extractall(zf, src_dir)
 
     def download_testdata(self, submission_id: str, dest_dir: pathlib.Path):
         """Download testdata zip and extract to dest_dir/testcase/."""
@@ -148,7 +156,7 @@ class Runner:
         testcase_dir = dest_dir / 'testcase'
         testcase_dir.mkdir(exist_ok=True)
         with ZipFile(io.BytesIO(resp.content)) as zf:
-            zf.extractall(testcase_dir)
+            _safe_extractall(zf, testcase_dir)
 
     def send_heartbeat(self, submission_id: str):
         """Send heartbeat to extend claim timeout."""
@@ -239,6 +247,13 @@ class Runner:
                 ).compile()
                 logger.info(f'Compile result: {compile_result["Status"]}')
 
+            # Read config once for host path resolution
+            with open('.config/submission.json') as f:
+                s_config = json.load(f)
+            host_base = pathlib.Path(
+                s_config['working_dir']) / submission_id / 'testcase'
+            container_base = submission_dir / 'testcase'
+
             # Execute each test case
             results = {}
             for i, task in enumerate(meta.tasks):
@@ -256,14 +271,6 @@ class Runner:
                             'status': 'CE',
                         }
                         continue
-
-                    # Build paths
-                    # Read config to get working_dir for host paths
-                    with open('.config/submission.json') as f:
-                        s_config = json.load(f)
-                    host_base = pathlib.Path(
-                        s_config['working_dir']) / submission_id / 'testcase'
-                    container_base = submission_dir / 'testcase'
 
                     in_path = str((host_base / f'{case_no}.in').absolute())
                     out_path = str(

--- a/tests/test_runner_client.py
+++ b/tests/test_runner_client.py
@@ -21,7 +21,8 @@ def reset_module_globals(tmp_path, monkeypatch):
     monkeypatch.setattr(runner_client, 'RUNNER_NAME', 'test-runner')
     monkeypatch.setattr(runner_client, 'POLL_INTERVAL', 1)
     monkeypatch.setattr(runner_client, 'MAX_CONCURRENT', 4)
-    monkeypatch.setattr(runner_client, 'SUBMISSION_DIR', tmp_path / 'submissions')
+    monkeypatch.setattr(runner_client, 'SUBMISSION_DIR',
+                        tmp_path / 'submissions')
     (tmp_path / 'submissions').mkdir()
 
 
@@ -41,18 +42,24 @@ def _make_zip(files: dict[str, str]) -> bytes:
 
 # ── poll_for_jobs ────────────────────────────────────────────────
 
+
 class TestPollForJobs:
+
     def test_returns_jobs_on_success(self, runner):
         jobs = [{'submissionId': 'abc123'}]
         runner.session.get = MagicMock(return_value=MagicMock(
             ok=True,
-            json=MagicMock(return_value={'data': {'jobs': jobs}}),
+            json=MagicMock(return_value={'data': {
+                'jobs': jobs
+            }}),
         ))
         assert runner.poll_for_jobs() == jobs
 
     def test_returns_empty_on_http_error(self, runner):
         runner.session.get = MagicMock(return_value=MagicMock(
-            ok=False, status_code=500, text='Internal Server Error',
+            ok=False,
+            status_code=500,
+            text='Internal Server Error',
         ))
         assert runner.poll_for_jobs() == []
 
@@ -63,14 +70,18 @@ class TestPollForJobs:
 
 # ── claim_job ────────────────────────────────────────────────────
 
+
 class TestClaimJob:
+
     def test_returns_job_info_on_success(self, runner):
         data = {
             'submissionId': 'abc123',
             'problemId': 1,
             'language': 0,
             'token': 'tok',
-            'meta': {'tasks': []},
+            'meta': {
+                'tasks': []
+            },
         }
         runner.session.post = MagicMock(return_value=MagicMock(
             ok=True,
@@ -88,13 +99,15 @@ class TestClaimJob:
 
     def test_returns_none_on_conflict(self, runner):
         runner.session.post = MagicMock(return_value=MagicMock(
-            ok=False, status_code=409,
+            ok=False,
+            status_code=409,
         ))
         assert runner.claim_job('abc123') is None
 
     def test_returns_none_on_other_error(self, runner):
         runner.session.post = MagicMock(return_value=MagicMock(
-            ok=False, status_code=500,
+            ok=False,
+            status_code=500,
         ))
         assert runner.claim_job('abc123') is None
 
@@ -105,7 +118,9 @@ class TestClaimJob:
 
 # ── download_code / download_testdata ────────────────────────────
 
+
 class TestDownloads:
+
     def test_download_code_extracts_to_src(self, runner, tmp_path):
         zip_bytes = _make_zip({'main.c': '#include <stdio.h>'})
         runner.session.get = MagicMock(return_value=MagicMock(
@@ -141,7 +156,9 @@ class TestDownloads:
 
 # ── send_heartbeat ───────────────────────────────────────────────
 
+
 class TestHeartbeat:
+
     def test_send_heartbeat_posts_correctly(self, runner):
         runner.session.post = MagicMock()
         runner.send_heartbeat('abc123')
@@ -158,16 +175,26 @@ class TestHeartbeat:
 
 # ── report_result ────────────────────────────────────────────────
 
+
 class TestReportResult:
+
     def test_report_result_success(self, runner):
         runner.session.put = MagicMock(return_value=MagicMock(ok=True))
-        tasks = [[{'status': 'AC', 'stdout': '', 'stderr': '',
-                    'exitCode': 0, 'execTime': 100, 'memoryUsage': 1024}]]
+        tasks = [[{
+            'status': 'AC',
+            'stdout': '',
+            'stderr': '',
+            'exitCode': 0,
+            'execTime': 100,
+            'memoryUsage': 1024
+        }]]
         assert runner.report_result('abc123', 'tok', tasks) is True
 
     def test_report_result_failure(self, runner):
         runner.session.put = MagicMock(return_value=MagicMock(
-            ok=False, status_code=500, text='error',
+            ok=False,
+            status_code=500,
+            text='error',
         ))
         assert runner.report_result('abc123', 'tok', []) is False
 
@@ -181,7 +208,9 @@ class TestReportResult:
 
 # ── run (main loop) ─────────────────────────────────────────────
 
+
 class TestRunLoop:
+
     def test_shutdown_stops_loop(self, runner):
         """Runner should exit when shutdown is set."""
         runner.poll_for_jobs = MagicMock(return_value=[])
@@ -237,6 +266,7 @@ class TestRunLoop:
 
         runner.poll_for_jobs = poll_then_shutdown
         runner.claim_job = MagicMock(return_value=job_info)
+
         # Mock process_job to also decrement running_jobs (like the real finally block)
         def mock_process(job):
             with runner.running_lock:

--- a/tests/test_runner_client.py
+++ b/tests/test_runner_client.py
@@ -2,6 +2,7 @@ import io
 import json
 import pathlib
 import threading
+import time
 from unittest.mock import MagicMock, patch, PropertyMock
 from zipfile import ZipFile
 
@@ -194,57 +195,56 @@ class TestRunLoop:
 
     def test_skips_poll_when_no_slots(self, runner):
         """When all slots are occupied, runner should not poll."""
-        runner.running_jobs = runner.__class__.__init__  # just reset
-        runner = Runner()
         with runner.running_lock:
             runner.running_jobs = 4  # MAX_CONCURRENT
 
-        call_count = 0
-        original_poll = runner.poll_for_jobs
+        poll_called = False
 
         def counting_poll():
-            nonlocal call_count
-            call_count += 1
-            runner.shutdown = True
+            nonlocal poll_called
+            poll_called = True
             return []
 
         runner.poll_for_jobs = counting_poll
 
-        # Run in a thread with a timeout so it doesn't hang
-        t = threading.Thread(target=runner.run)
-        t.start()
-        t.join(timeout=5)
+        # On first sleep (slots full), set shutdown and reset running_jobs
+        # so the drain loop also exits immediately.
+        def mock_sleep(_):
+            runner.shutdown = True
+            with runner.running_lock:
+                runner.running_jobs = 0
+
+        with patch.object(runner_client.time, 'sleep', side_effect=mock_sleep):
+            runner.run()
+
         # poll should not have been called since slots were full
-        # (the loop sleeps then re-checks; shutdown gets set on first poll if it happens)
-        # Either 0 calls (skipped) or 1 call (raced) is acceptable
-        assert call_count <= 1
+        assert not poll_called
 
     def test_claims_and_processes_jobs(self, runner):
         """Runner should claim available jobs and spawn processing threads."""
         jobs = [{'submissionId': 'sub1'}]
         job_info = JobInfo('sub1', 1, 0, 'tok', {})
 
-        runner.poll_for_jobs = MagicMock(side_effect=[jobs, []])
+        call_count = 0
+
+        def poll_then_shutdown():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return jobs
+            runner.shutdown = True
+            return []
+
+        runner.poll_for_jobs = poll_then_shutdown
         runner.claim_job = MagicMock(return_value=job_info)
-        runner.process_job = MagicMock()
+        # Mock process_job to also decrement running_jobs (like the real finally block)
+        def mock_process(job):
+            with runner.running_lock:
+                runner.running_jobs -= 1
 
-        poll_count = 0
-        original_poll = runner.poll_for_jobs
+        runner.process_job = MagicMock(side_effect=mock_process)
 
-        def poll_then_shutdown(*args, **kwargs):
-            nonlocal poll_count
-            result = original_poll(*args, **kwargs)
-            poll_count += 1
-            if poll_count >= 2:
-                runner.shutdown = True
-            return result
-
-        runner.poll_for_jobs = MagicMock(side_effect=poll_then_shutdown)
-        runner.claim_job = MagicMock(return_value=job_info)
-        runner.process_job = MagicMock(side_effect=lambda j: None)
-
-        # Patch time.sleep to speed up
-        with patch('time.sleep', return_value=None):
+        with patch.object(runner_client.time, 'sleep', return_value=None):
             runner.run()
 
         runner.claim_job.assert_called_with('sub1')

--- a/tests/test_runner_client.py
+++ b/tests/test_runner_client.py
@@ -1,0 +1,250 @@
+import io
+import json
+import pathlib
+import threading
+from unittest.mock import MagicMock, patch, PropertyMock
+from zipfile import ZipFile
+
+import pytest
+import requests
+
+import runner_client
+from runner_client import JobInfo, Runner
+
+
+@pytest.fixture(autouse=True)
+def reset_module_globals(tmp_path, monkeypatch):
+    """Reset module-level globals for each test."""
+    monkeypatch.setattr(runner_client, 'BACKEND_API', 'http://test:8080')
+    monkeypatch.setattr(runner_client, 'RUNNER_TOKEN', 'test-token')
+    monkeypatch.setattr(runner_client, 'RUNNER_NAME', 'test-runner')
+    monkeypatch.setattr(runner_client, 'POLL_INTERVAL', 1)
+    monkeypatch.setattr(runner_client, 'MAX_CONCURRENT', 4)
+    monkeypatch.setattr(runner_client, 'SUBMISSION_DIR', tmp_path / 'submissions')
+    (tmp_path / 'submissions').mkdir()
+
+
+@pytest.fixture
+def runner():
+    return Runner()
+
+
+def _make_zip(files: dict[str, str]) -> bytes:
+    """Create an in-memory zip with the given {filename: content} mapping."""
+    buf = io.BytesIO()
+    with ZipFile(buf, 'w') as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+# ── poll_for_jobs ────────────────────────────────────────────────
+
+class TestPollForJobs:
+    def test_returns_jobs_on_success(self, runner):
+        jobs = [{'submissionId': 'abc123'}]
+        runner.session.get = MagicMock(return_value=MagicMock(
+            ok=True,
+            json=MagicMock(return_value={'data': {'jobs': jobs}}),
+        ))
+        assert runner.poll_for_jobs() == jobs
+
+    def test_returns_empty_on_http_error(self, runner):
+        runner.session.get = MagicMock(return_value=MagicMock(
+            ok=False, status_code=500, text='Internal Server Error',
+        ))
+        assert runner.poll_for_jobs() == []
+
+    def test_returns_empty_on_network_error(self, runner):
+        runner.session.get = MagicMock(side_effect=requests.ConnectionError)
+        assert runner.poll_for_jobs() == []
+
+
+# ── claim_job ────────────────────────────────────────────────────
+
+class TestClaimJob:
+    def test_returns_job_info_on_success(self, runner):
+        data = {
+            'submissionId': 'abc123',
+            'problemId': 1,
+            'language': 0,
+            'token': 'tok',
+            'meta': {'tasks': []},
+        }
+        runner.session.post = MagicMock(return_value=MagicMock(
+            ok=True,
+            status_code=200,
+            json=MagicMock(return_value={'data': data}),
+        ))
+        job = runner.claim_job('abc123')
+        assert job == JobInfo(
+            submission_id='abc123',
+            problem_id=1,
+            language=0,
+            token='tok',
+            meta={'tasks': []},
+        )
+
+    def test_returns_none_on_conflict(self, runner):
+        runner.session.post = MagicMock(return_value=MagicMock(
+            ok=False, status_code=409,
+        ))
+        assert runner.claim_job('abc123') is None
+
+    def test_returns_none_on_other_error(self, runner):
+        runner.session.post = MagicMock(return_value=MagicMock(
+            ok=False, status_code=500,
+        ))
+        assert runner.claim_job('abc123') is None
+
+    def test_returns_none_on_network_error(self, runner):
+        runner.session.post = MagicMock(side_effect=requests.ConnectionError)
+        assert runner.claim_job('abc123') is None
+
+
+# ── download_code / download_testdata ────────────────────────────
+
+class TestDownloads:
+    def test_download_code_extracts_to_src(self, runner, tmp_path):
+        zip_bytes = _make_zip({'main.c': '#include <stdio.h>'})
+        runner.session.get = MagicMock(return_value=MagicMock(
+            content=zip_bytes,
+            raise_for_status=MagicMock(),
+        ))
+        dest = tmp_path / 'job1'
+        dest.mkdir()
+        runner.download_code('job1', dest)
+        assert (dest / 'src' / 'main.c').read_text() == '#include <stdio.h>'
+
+    def test_download_testdata_extracts_to_testcase(self, runner, tmp_path):
+        zip_bytes = _make_zip({'0000.in': '1 2\n', '0000.out': '3\n'})
+        runner.session.get = MagicMock(return_value=MagicMock(
+            content=zip_bytes,
+            raise_for_status=MagicMock(),
+        ))
+        dest = tmp_path / 'job1'
+        dest.mkdir()
+        runner.download_testdata('job1', dest)
+        assert (dest / 'testcase' / '0000.in').read_text() == '1 2\n'
+        assert (dest / 'testcase' / '0000.out').read_text() == '3\n'
+
+    def test_download_code_raises_on_http_error(self, runner, tmp_path):
+        resp = MagicMock()
+        resp.raise_for_status.side_effect = requests.HTTPError('404')
+        runner.session.get = MagicMock(return_value=resp)
+        dest = tmp_path / 'job1'
+        dest.mkdir()
+        with pytest.raises(requests.HTTPError):
+            runner.download_code('job1', dest)
+
+
+# ── send_heartbeat ───────────────────────────────────────────────
+
+class TestHeartbeat:
+    def test_send_heartbeat_posts_correctly(self, runner):
+        runner.session.post = MagicMock()
+        runner.send_heartbeat('abc123')
+        runner.session.post.assert_called_once()
+        args, kwargs = runner.session.post.call_args
+        assert 'heartbeat' in args[0]
+        assert kwargs['json']['submissionId'] == 'abc123'
+
+    def test_send_heartbeat_swallows_errors(self, runner):
+        runner.session.post = MagicMock(side_effect=requests.ConnectionError)
+        # Should not raise
+        runner.send_heartbeat('abc123')
+
+
+# ── report_result ────────────────────────────────────────────────
+
+class TestReportResult:
+    def test_report_result_success(self, runner):
+        runner.session.put = MagicMock(return_value=MagicMock(ok=True))
+        tasks = [[{'status': 'AC', 'stdout': '', 'stderr': '',
+                    'exitCode': 0, 'execTime': 100, 'memoryUsage': 1024}]]
+        assert runner.report_result('abc123', 'tok', tasks) is True
+
+    def test_report_result_failure(self, runner):
+        runner.session.put = MagicMock(return_value=MagicMock(
+            ok=False, status_code=500, text='error',
+        ))
+        assert runner.report_result('abc123', 'tok', []) is False
+
+    def test_report_result_sends_correct_payload(self, runner):
+        runner.session.put = MagicMock(return_value=MagicMock(ok=True))
+        tasks = [['task0_case0']]
+        runner.report_result('sub1', 'my-token', tasks)
+        _, kwargs = runner.session.put.call_args
+        assert kwargs['json'] == {'tasks': tasks, 'token': 'my-token'}
+
+
+# ── run (main loop) ─────────────────────────────────────────────
+
+class TestRunLoop:
+    def test_shutdown_stops_loop(self, runner):
+        """Runner should exit when shutdown is set."""
+        runner.poll_for_jobs = MagicMock(return_value=[])
+
+        def set_shutdown(*_args):
+            runner.shutdown = True
+
+        runner.poll_for_jobs.side_effect = set_shutdown
+        runner.run()
+        # If we get here, the loop exited correctly
+
+    def test_skips_poll_when_no_slots(self, runner):
+        """When all slots are occupied, runner should not poll."""
+        runner.running_jobs = runner.__class__.__init__  # just reset
+        runner = Runner()
+        with runner.running_lock:
+            runner.running_jobs = 4  # MAX_CONCURRENT
+
+        call_count = 0
+        original_poll = runner.poll_for_jobs
+
+        def counting_poll():
+            nonlocal call_count
+            call_count += 1
+            runner.shutdown = True
+            return []
+
+        runner.poll_for_jobs = counting_poll
+
+        # Run in a thread with a timeout so it doesn't hang
+        t = threading.Thread(target=runner.run)
+        t.start()
+        t.join(timeout=5)
+        # poll should not have been called since slots were full
+        # (the loop sleeps then re-checks; shutdown gets set on first poll if it happens)
+        # Either 0 calls (skipped) or 1 call (raced) is acceptable
+        assert call_count <= 1
+
+    def test_claims_and_processes_jobs(self, runner):
+        """Runner should claim available jobs and spawn processing threads."""
+        jobs = [{'submissionId': 'sub1'}]
+        job_info = JobInfo('sub1', 1, 0, 'tok', {})
+
+        runner.poll_for_jobs = MagicMock(side_effect=[jobs, []])
+        runner.claim_job = MagicMock(return_value=job_info)
+        runner.process_job = MagicMock()
+
+        poll_count = 0
+        original_poll = runner.poll_for_jobs
+
+        def poll_then_shutdown(*args, **kwargs):
+            nonlocal poll_count
+            result = original_poll(*args, **kwargs)
+            poll_count += 1
+            if poll_count >= 2:
+                runner.shutdown = True
+            return result
+
+        runner.poll_for_jobs = MagicMock(side_effect=poll_then_shutdown)
+        runner.claim_job = MagicMock(return_value=job_info)
+        runner.process_job = MagicMock(side_effect=lambda j: None)
+
+        # Patch time.sleep to speed up
+        with patch('time.sleep', return_value=None):
+            runner.run()
+
+        runner.claim_job.assert_called_with('sub1')


### PR DESCRIPTION
Add runner_client.py that operates as a pull-based runner instead of the traditional push-based Flask server. The runner polls the backend for pending judge jobs, claims them, processes them in Docker containers, and reports results back — similar to GitHub Actions self-hosted runners.

Changes:
- runner_client.py: Polling-based runner with concurrent job processing, heartbeat support, and graceful shutdown
- Dockerfile: Support SANDBOX_MODE=pull env var to start runner client

https://claude.ai/code/session_01CD3q84rDaDXMnAmQVh58qR