### PR TITLE
ci: publish Docker images to GHCR and skip tests when Docker unavailable

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -46,9 +46,13 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       
-      - name: Build sandbox
-        run: ./build.sh
-      
+      - name: Pull Docker images
+        run: |
+          docker pull ghcr.io/normal-oj/noj-c-cpp:latest || true
+          docker pull ghcr.io/normal-oj/noj-py3:latest || true
+          docker tag ghcr.io/normal-oj/noj-c-cpp:latest noj-c-cpp || true
+          docker tag ghcr.io/normal-oj/noj-py3:latest noj-py3 || true
+
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,56 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'c_cpp_dockerfile'
+      - 'python3_dockerfile'
+
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download sandbox binary
+        run: |
+          wget https://github.com/Normal-OJ/C-Sandbox/releases/latest/download/sandbox
+          chmod +x sandbox
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push noj-c-cpp
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: c_cpp_dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/normal-oj/noj-c-cpp:latest
+            ${{ env.REGISTRY }}/normal-oj/noj-c-cpp:${{ github.sha }}
+
+      - name: Build and push noj-py3
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: python3_dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/normal-oj/noj-py3:latest
+            ${{ env.REGISTRY }}/normal-oj/noj-py3:${{ github.sha }}

--- a/tests/test_submission_runner.py
+++ b/tests/test_submission_runner.py
@@ -1,5 +1,19 @@
 import json
 import pytest
+import docker
+
+
+def _docker_available():
+    try:
+        client = docker.APIClient()
+        client.ping()
+        return True
+    except Exception:
+        return False
+
+
+needs_docker = pytest.mark.skipif(not _docker_available(),
+                                  reason='Docker is not available')
 
 
 @pytest.mark.parametrize(
@@ -30,6 +44,7 @@ def test_strip_func(TestSubmissionRunner, stdout, answer, excepted):
         answer)) is excepted
 
 
+@needs_docker
 def test_c_tle(submission_generator, TestSubmissionRunner):
     submission_id = [
         _id for _id, pn in submission_generator.submission_ids.items()
@@ -52,6 +67,7 @@ def test_c_tle(submission_generator, TestSubmissionRunner):
     assert res['Status'] == 'TLE', json.dumps(res)
 
 
+@needs_docker
 def test_non_strict_diff(submission_generator, TestSubmissionRunner):
     submission_id = [
         _id for _id, pn in submission_generator.submission_ids.items()


### PR DESCRIPTION
- Add publish-docker-image.yml workflow to build and push noj-c-cpp and noj-py3 images to ghcr.io on Dockerfile changes
- Update CI to pull pre-built images from GHCR instead of building via build.sh each time
- Add @needs_docker skip marker to test_c_tle and test_non_strict_diff so they gracefully skip when Docker is not available

https://claude.ai/code/session_01CD3q84rDaDXMnAmQVh58qR